### PR TITLE
Indieauth improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Lasso
 
-an SSO solution for nginx using the [auth_request](http://nginx.org/en/docs/http/ngx_http_auth_request_module.html) module
+an SSO solution for nginx using the [auth_request](http://nginx.org/en/docs/http/ngx_http_auth_request_module.html) module.
 
-lasso supports OAuth login to google apps, [github](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/) and [indieauth](https://indieauth.com/developers)
+lasso supports OAuth login via Google, [GitHub](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/), [IndieAuth](https://indieauth.spec.indieweb.org/), and OpenID Connect providers.
 
 If lasso is running on the same host as the nginx reverse proxy the response time from the `/validate` endpoint to nginx should be less than 1ms
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -545,12 +545,6 @@ func getUserInfoFromGithub(client *http.Client, user *structs.User, ptoken *oaut
 	return nil
 }
 
-// indieauth
-// https://indieauth.com/developers
-type indieResponse struct {
-	Email string `json:"me"`
-}
-
 func getUserInfoFromIndieAuth(r *http.Request, user *structs.User) error {
 
 	code := r.URL.Query().Get("code")
@@ -597,13 +591,13 @@ func getUserInfoFromIndieAuth(r *http.Request, user *structs.User) error {
 	defer userinfo.Body.Close()
 	data, _ := ioutil.ReadAll(userinfo.Body)
 	log.Println("indieauth userinfo body: ", string(data))
-	ir := indieResponse{}
-	if err := json.Unmarshal(data, &ir); err != nil {
+	iaUser := structs.IndieAuthUser{}
+	if err = json.Unmarshal(data, &iaUser); err != nil {
 		log.Errorln(err)
 		return err
 	}
-	user.Email = ir.Email
-	user.PrepareUserData()
+	iaUser.PrepareUserData()
+	user.Username = iaUser.Username
 	log.Debug(user)
 	return nil
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -107,6 +107,8 @@ func loginURL(r *http.Request, state string) string {
 			}
 		}
 		url = oauthclient.AuthCodeURL(state, oauthopts)
+	} else if genOauth.Provider == "indieauth" {
+		url = oauthclient.AuthCodeURL(state, oauth2.SetAuthURLParam("response_type", "id"))
 	} else {
 		url = oauthclient.AuthCodeURL(state)
 	}

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -55,6 +55,15 @@ func (u *GithubUser) PrepareUserData() {
 	u.Username = u.Login
 }
 
+type IndieAuthUser struct {
+	User
+	URL   string `json:"me"`
+}
+
+func (u *IndieAuthUser) PrepareUserData() {
+	u.Username = u.URL
+}
+
 // GenericOauth provides endoint for access
 type GenericOauth struct {
 	ClientID        string   `mapstructure:"client_id"`

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -7,11 +7,11 @@ type UserI interface {
 
 // User is inherited.
 type User struct {
+	Username   string `json:"username",mapstructure:"username"`
 	Name       string `json:"name"`
 	Email      string `json:"email"`
 	CreatedOn  int64  `json:"createdon"`
 	LastUpdate int64  `json:"lastupdate"`
-	Username   string `json:"username",mapstructure:"username"`
 	ID         int    `json:"id",mapstructure:"id"`
 	// jwt.StandardClaims
 }


### PR DESCRIPTION
* request `response_type=id` to avoid requesting an access token from the IndieAuth provider
* refactor IndieAuth code to more closely match the GitHub model
* update IndieAuth info in the readme