### PR TITLE
Lets show a help command if needed, and add a flag for port

### DIFF
--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -130,16 +130,16 @@ func init() {
 		os.Exit(1)
 	}
 
-	if *port != -1 {
-		Cfg.Port = *port
-	}
-
 	if *ll == "debug" {
 		log.SetLevel(log.DebugLevel)
 		log.Debug("logLevel set to debug")
 	}
 
 	setDefaults()
+
+	if *port != -1 {
+		Cfg.Port = *port
+	}
 
 	errT := BasicTest()
 	if errT != nil {

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -122,7 +122,18 @@ func init() {
 
 	// can pass loglevel on the command line
 	var ll = flag.String("loglevel", Cfg.LogLevel, "enable debug log output")
+	var port = flag.Int("port", -1, "port")
+	var help = flag.Bool("help", false, "show usage")
 	flag.Parse()
+	if *help {
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	if *port != -1 {
+		Cfg.Port = *port
+	}
+
 	if *ll == "debug" {
 		log.SetLevel(log.DebugLevel)
 		log.Debug("logLevel set to debug")


### PR DESCRIPTION
I wanted to be able to override the config file using arguments, so i could hard code a couple values in the helm chart.

Decided a help/usage flag was useful too.

```
./lasso -h
Usage of ./lasso:
  -help        show usage
  -loglevel string        enable debug log output (default "debug") 
 -port int        port (default -1)
```
