### PR TITLE
Smaller docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+config/config.yml
+data/lasso_bolt.db
+pkg/model/storage-test.db
+main
+config/google_config.json
+.vscode/*
+lasso
+config/config.yml_google
+config/config.yml_github
+config/secret
+config/config.yml_orig
+.dockerignore
+Dockerfile
+handlers/rice-box.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,26 @@
 # lassoproject/lasso
 # https://github.com/LassoProject/lasso
-FROM golang:1.10
+FROM golang:1.10 AS builder
 
 LABEL maintainer="lasso@bnf.net"
 
 RUN mkdir -p ${GOPATH}/src/github.com/LassoProject/lasso
 WORKDIR ${GOPATH}/src/github.com/LassoProject/lasso
-    
+
 COPY . .
 
 # RUN go-wrapper download  # "go get -d -v ./..."
 # RUN ./do.sh build    # see `do.sh` for lasso build details
 # RUN go-wrapper install # "go install -v ./..."
 
-RUN go get -d -v ./...
-RUN ./do.sh build    # see `do.sh` for lasso build details
+RUN ./do.sh goget
+RUN ./do.sh gobuildstatic # see `do.sh` for lasso build details
 RUN ./do.sh install
 
-RUN rm -rf ./config ./data \
-    && ln -s /config ./config \
-    && ln -s /data ./data 
-
+FROM scratch
+LABEL maintainer="lasso@bnf.net"
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY templates/ templates/
+COPY --from=builder /go/bin/lasso /lasso
 EXPOSE 9090
-CMD ["/go/bin/lasso"] 
+ENTRYPOINT ["/lasso"]

--- a/do.sh
+++ b/do.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # change dir to where this script is running
 CURDIR=${PWD}

--- a/do.sh
+++ b/do.sh
@@ -41,10 +41,9 @@ dbuild () {
 }
 
 gobuildstatic () {
-  # TODO: this doesn't include the templates
-  # https://github.com/shurcooL/vfsgen
-
-  CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
+  export CGO_ENABLED=0
+  export GOOS=linux
+  build
 }
 
 drun () {


### PR DESCRIPTION
```
for i in lassoproject/lasso docker-registry.home.gavinmogan.com/lasso; do echo $i; docker image inspect $i --format='{{.Size}}';done
lassoproject/lasso
919890453
docker-registry.home.gavinmogan.com/lasso
13431173
```

Was nearly a gig, now about 13MB

Also moved the binary to entrypoint, so you can do `docker run lassoproject/lasso --help` and get the actual help andnot have to type lasso/vouch again