### PR TITLE
when HD is provided, but blank, and you have multiple accounts logged in, it forces a login page, not an account selector

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -70,7 +70,11 @@ func loginURL(r *http.Request, state string) string {
 				break
 			}
 		}
-		url = cfg.OAuthClient.AuthCodeURL(state, cfg.OAuthopts)
+		if cfg.OAuthopts != nil {
+			url = cfg.OAuthClient.AuthCodeURL(state, cfg.OAuthopts)
+		} else {
+			url = cfg.OAuthClient.AuthCodeURL(state)
+		}
 	} else if cfg.GenOAuth.Provider == cfg.Providers.IndieAuth {
 		url = cfg.OAuthClient.AuthCodeURL(state, oauth2.SetAuthURLParam("response_type", "id"))
 	} else {

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -305,8 +305,6 @@ func setDefaultsGoogle() {
 	if GenOAuth.PreferredDomain != "" {
 		log.Infof("setting Google OAuth preferred login domain param 'hd' to %s", GenOAuth.PreferredDomain)
 		OAuthopts = oauth2.SetAuthURLParam("hd", GenOAuth.PreferredDomain)
-	} else {
-		OAuthopts = oauth2.SetAuthURLParam("hd", "")
 	}
 }
 


### PR DESCRIPTION
So every time I went to a lasso enabled site on my desktop, I'd have to login with username and password again.

This just makes it not provide the parameter if its unset.